### PR TITLE
1Password - Bump to 6.6.1.BETA-2

### DIFF
--- a/Casks/1password-halyard.rb
+++ b/Casks/1password-halyard.rb
@@ -1,6 +1,6 @@
 cask '1password-halyard' do
-  version '6.6.BETA-11'
-  sha256 '047d4f1f5964129b929c017c72ae19cff02b5ab7965aa464a3b93e439e27b294'
+  version '6.6.1.BETA-2'
+  sha256 '4b063e40a26449cb88bf6a2830733b2618c07b64578bf9242c2ee29bef53fb03'
 
   url "https://cache.agilebits.com/dist/1P/mac4/1Password-#{version}.zip"
   homepage 'https://agilebits.com/onepassword'


### PR DESCRIPTION
https://app-updates.agilebits.com/product_history/OPM4#v661002

```
Good afternoon! This build is a re-release of 1Password 6.6.1.BETA-1 with a fix for the expired provisioning profile that was preventing 1Password from launching. Our apologies for the confusion!

Head over to join us in our discussion forums our forums to provide feedback and report any issues.

FIXED
Updated the provisioning profile so 1Password will launch.
```