### PR TITLE
1Password - Bump to BETA3

### DIFF
--- a/Casks/1password-halyard.rb
+++ b/Casks/1password-halyard.rb
@@ -1,6 +1,6 @@
 cask '1password-halyard' do
-  version '6.6.1.BETA-2'
-  sha256 '4b063e40a26449cb88bf6a2830733b2618c07b64578bf9242c2ee29bef53fb03'
+  version '6.6.1.BETA-3'
+  sha256 '434bf67583ea2eb4cf098f07bd3dc4dabd8f865c50d73f36f5a035be9d31e237'
 
   url "https://cache.agilebits.com/dist/1P/mac4/1Password-#{version}.zip"
   homepage 'https://agilebits.com/onepassword'


### PR DESCRIPTION
https://app-updates.agilebits.com/product_history/OPM4#v661003
This is only slightly annoying....

```
NOTICE! Automatically updating to this version will not work. Please download directly from our update site here: https://app-updates.agilebits.com/download/OPM4.

If you continue to have trouble please visit our support site for more information.

Good afternoon! This build is a re-release of 1Password 6.5.3 with a fix for the expired provisioning profile that was preventing 1Password from launching. Our apologies for the confusion!

FIXED
Updated the provisioning profile so 1Password will launch.
```