### PR TITLE
Invalid Dropbox URI

### DIFF
--- a/Casks/dropbox-halyard.rb
+++ b/Casks/dropbox-halyard.rb
@@ -2,7 +2,7 @@ cask 'dropbox-halyard' do
   version '49.4.68'
   sha256 'eea540c767601895c0694d5a3d72b36dd45bedfc2f2669e00ca23b7437226c07'
 
-  url "https://clientupdates.dropboxstatic.com/dbx-releng/client/Dropbox\%20#{version}.dmg"
+  url "https://clientupdates.dropboxstatic.com/dbx-releng/client/Dropbox%20#{version}.dmg"
   homepage 'https://www.dropbox.com/'
   name 'Dropbox'
 

--- a/Casks/dropbox-halyard.rb
+++ b/Casks/dropbox-halyard.rb
@@ -2,7 +2,7 @@ cask 'dropbox-halyard' do
   version '49.4.68'
   sha256 'eea540c767601895c0694d5a3d72b36dd45bedfc2f2669e00ca23b7437226c07'
 
-  url "https://clientupdates.dropboxstatic.com/dbx-releng/client/Dropbox #{version}.dmg"
+  url "https://clientupdates.dropboxstatic.com/dbx-releng/client/Dropbox\ #{version}.dmg"
   homepage 'https://www.dropbox.com/'
   name 'Dropbox'
 

--- a/Casks/dropbox-halyard.rb
+++ b/Casks/dropbox-halyard.rb
@@ -2,7 +2,7 @@ cask 'dropbox-halyard' do
   version '49.4.68'
   sha256 'eea540c767601895c0694d5a3d72b36dd45bedfc2f2669e00ca23b7437226c07'
 
-  url "https://clientupdates.dropboxstatic.com/dbx-releng/client/Dropbox\ #{version}.dmg"
+  url "https://clientupdates.dropboxstatic.com/dbx-releng/client/Dropbox\%20#{version}.dmg"
   homepage 'https://www.dropbox.com/'
   name 'Dropbox'
 


### PR DESCRIPTION
```
Jareds-MacBook-Pro:~ ghavil$ /opt/brew/bin/brew cask search slack
Error: Cask 'dropbox-halyard' definition is invalid: 'url' stanza failed with: bad URI(is not URI?): https://clientupdates.dropboxstatic.com/dbx-releng/client/Dropbox 49.4.68.dmg
```

I _think_ this'll work